### PR TITLE
Fixing auto-scaler issue when primary enabled - PAAS-55

### DIFF
--- a/conf.sh
+++ b/conf.sh
@@ -31,6 +31,11 @@ export log_path=/var/log/apache-stratos
 export stratos_domain=""
 export machine_ip=""
 export host_user=""
+export SLEEPTIME=30
+export PPAAS_PORT=9443
+export BAM_PORT=9444
+export IS_PORT=9445
+export GITBLIT_PORT=9418
 
 # Puppet master configuration
 export skip_puppet=""

--- a/resources/json/ec2/autoscale-policy.json
+++ b/resources/json/ec2/autoscale-policy.json
@@ -7,7 +7,7 @@
         "secondDerivative": "0.2"        
       },
       "memoryConsumption": {
-        "average": "800",
+        "average": "80",
         "gradient": "10",
         "secondDerivative": "0.2"        
       },

--- a/resources/json/os/autoscale-policy.json
+++ b/resources/json/os/autoscale-policy.json
@@ -7,7 +7,7 @@
         "secondDerivative": "0.2"        
       },
       "memoryConsumption": {
-        "average": "800",
+        "average": "80",
         "gradient": "10",
         "secondDerivative": "0.2"        
       },

--- a/source/products/stratos/modules/distribution/src/main/conf/mincheck.drl
+++ b/source/products/stratos/modules/distribution/src/main/conf/mincheck.drl
@@ -49,6 +49,7 @@ global java.util.Map partitionCtxts;
 global java.lang.String clusterId;
 global java.lang.String lbRef;
 global java.lang.Boolean isPrimary;
+global Integer primaryMemberCount;
 
 rule "Minimum Rule"
 dialect "mvel"
@@ -57,11 +58,14 @@ dialect "mvel"
            eval(log.debug("Running minimum rule: [network-partition] " + $ctxt.getNetworkPartitionId() + " [partition] " + $ctxt.getPartitionId()))
 	       eval(log.debug("[min-check] [network-partition] " + $ctxt.getNetworkPartitionId() + " [partition] " + $ctxt.getPartitionId() + " Non terminated member count: " + $ctxt.getNonTerminatedMemberCount()))
 	       eval(log.debug("[min-check] [network-partition] " + $ctxt.getNetworkPartitionId() + " [partition] " + $ctxt.getPartitionId() + " Minimum member count: " + $ctxt.getMinimumMemberCount()))
-	       eval($ctxt.getNonTerminatedMemberCount() < $ctxt.getMinimumMemberCount())
-
+	       eval ( (isPrimary && (primaryMemberCount < $ctxt.getMinimumMemberCount() )) || ( !isPrimary && ($ctxt.getNonTerminatedMemberCount() < $ctxt.getMinimumMemberCount() )) )
        then
+           if (isPrimary){
+              log.debug("[min-check] true  [primary] true   [primary member count] " + primaryMemberCount);
+           } else{
+              log.debug("[min-check] true  [primary] false");
+           }
 	       $delegator.delegateSpawn($ctxt, clusterId, lbRef, isPrimary);
-	       
 end
 
 rule "Terminate Obsoleted Instances"


### PR DESCRIPTION
Auto scaler separately identifies member count for primary members and non-primary members when executing min-check rule.

Improved boot.sh to wait until ports are active when starting servers
