### PR TITLE
Setup_bam_logging.sh fails silently on re-install

### DIFF
--- a/stratos-installer/setup_bam_logging.sh
+++ b/stratos-installer/setup_bam_logging.sh
@@ -112,7 +112,7 @@ sed -i "s@BAM_PASS@admin@g" repository/conf/cartridge-config.properties
 
 popd
 
-unzip -q $bam_pack_path -d $stratos_path
+unzip -o -q $bam_pack_path -d $stratos_path
 
 cp -f $current_dir/config/bam/repository/conf/etc/summarizer-config.xml $bam_path/repository/conf/etc/
 cp -f $current_dir/config/bam/repository/conf/advanced/hive-site.xml $bam_path/repository/conf/advanced/


### PR DESCRIPTION
Please review and merge

This PR contains the fixes for 
PAAS-140- Setup_bam_logging.sh fails silently on re-install