### PR TITLE
Changing plugin to support vm scenario

### DIFF
--- a/cartridges/docker/wso2esb-4.8.1/build.sh
+++ b/cartridges/docker/wso2esb-4.8.1/build.sh
@@ -44,7 +44,7 @@ if ${clean} ; then
    echo "----------------------------------"
    echo "Copying" ${wso2_product_type^^} - ${wso2_product_version} "python plugins"
    echo "----------------------------------"
-   rm ${script_path}/plugins/*
+   rm -f ${script_path}/plugins/*
    pushd ${wso2_product_plugin_path}
    cp * ${script_path}/plugins
    popd

--- a/cartridges/plugins/wso2am-1.9.0/wso2am-startup-handler.py
+++ b/cartridges/plugins/wso2am-1.9.0/wso2am-startup-handler.py
@@ -180,9 +180,9 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
             gateway_worker_ports = self.get_data_from_meta_data_service(app_id,
                                                                         self.CONST_CONFIG_PARAM_GATEWAY_WORKER_PORTS)
 
-            is_vm = self.check_vm_or_kubernetes(use_kubernetes, service_name, app_id)
+            environment_type = self.find_environment_type(use_kubernetes, service_name, app_id)
 
-            if is_vm:
+            if environment_type == 'Vm':
                 gateway_host_name = self.get_host_name_from_cluster(self.CONST_GATEWAY_MANAGER_SERVICE_NAME)
                 gateway_worker_host_name = self.get_host_name_from_cluster(self.CONST_GATEWAY_WORKER_SERVICE_NAME)
                 gateway_host = gateway_host_name
@@ -221,9 +221,9 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
             keymanager_ip = self.get_data_from_meta_data_service(app_id, self.ENV_CONFIG_PARAM_KEYMANAGER_IP)
             keymanager_ports = self.get_data_from_meta_data_service(app_id, self.CONST_CONFIG_PARAM_KEYMANAGER_PORTS)
 
-            is_vm = self.check_vm_or_kubernetes(use_kubernetes, service_name, app_id)
+            environment_type = self.find_environment_type(use_kubernetes, service_name, app_id)
 
-            if is_vm:
+            if environment_type == 'Vm':
                 keymanager_host_name = self.get_host_name_from_cluster(self.CONST_KEY_MANAGER_SERVICE_NAME)
                 keymanager_host = keymanager_host_name
                 self.update_hosts_file(keymanager_ip, keymanager_host_name)
@@ -259,9 +259,9 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
             keymanager_ip = self.get_data_from_meta_data_service(app_id, self.ENV_CONFIG_PARAM_KEYMANAGER_IP)
             keymanager_ports = self.get_data_from_meta_data_service(app_id, self.CONST_CONFIG_PARAM_KEYMANAGER_PORTS)
 
-            is_vm = self.check_vm_or_kubernetes(use_kubernetes, service_name, app_id)
+            environment_type = self.find_environment_type(use_kubernetes,service_name,app_id)
 
-            if is_vm:
+            if environment_type == 'Vm':
                 keymanager_host_name = self.get_host_name_from_cluster(self.CONST_KEY_MANAGER_SERVICE_NAME)
                 keymanager_host = keymanager_host_name
                 self.update_hosts_file(keymanager_ip, keymanager_host_name)
@@ -302,9 +302,9 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
             gateway_worker_ports = self.get_data_from_meta_data_service(app_id,
                                                                         self.CONST_CONFIG_PARAM_GATEWAY_WORKER_PORTS)
 
-            is_vm = self.check_vm_or_kubernetes(use_kubernetes, service_name, app_id)
+            environment_type = self.find_environment_type(use_kubernetes,service_name,app_id)
 
-            if is_vm:
+            if environment_type == 'Vm':
                 keymanager_host_name = self.get_host_name_from_cluster(self.CONST_KEY_MANAGER_SERVICE_NAME)
                 gateway_host_name = self.get_host_name_from_cluster(self.CONST_GATEWAY_MANAGER_SERVICE_NAME)
                 gateway_worker_host_name = self.get_host_name_from_cluster(self.CONST_GATEWAY_WORKER_SERVICE_NAME)
@@ -361,9 +361,9 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
             gateway_worker_ports = self.get_data_from_meta_data_service(app_id,
                                                                         self.CONST_CONFIG_PARAM_GATEWAY_WORKER_PORTS)
 
-            is_vm = self.check_vm_or_kubernetes(use_kubernetes, service_name, app_id)
+            environment_type = self.find_environment_type(use_kubernetes,service_name,app_id)
 
-            if is_vm:
+            if environment_type == 'Vm':
                 keymanager_host_name = self.get_host_name_from_cluster(self.CONST_KEY_MANAGER_SERVICE_NAME)
                 gateway_host_name = self.get_host_name_from_cluster(self.CONST_GATEWAY_MANAGER_SERVICE_NAME)
                 gateway_worker_host_name = self.get_host_name_from_cluster(self.CONST_GATEWAY_WORKER_SERVICE_NAME)
@@ -413,9 +413,9 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
             gateway_worker_ports = self.get_data_from_meta_data_service(app_id,
                                                                         self.CONST_CONFIG_PARAM_GATEWAY_WORKER_PORTS)
 
-            is_vm = self.check_vm_or_kubernetes(use_kubernetes, service_name, app_id)
+            environment_type = self.find_environment_type(use_kubernetes,service_name,app_id)
 
-            if is_vm:
+            if environment_type == 'Vm':
                 keymanager_host_name = self.get_host_name_from_cluster(self.CONST_KEY_MANAGER_SERVICE_NAME)
                 gateway_host_name = self.get_host_name_from_cluster(self.CONST_GATEWAY_MANAGER_SERVICE_NAME)
                 gateway_worker_host_name = self.get_host_name_from_cluster(self.CONST_GATEWAY_WORKER_SERVICE_NAME)
@@ -758,20 +758,20 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
         return clusters
 
 
-    def check_vm_or_kubernetes(self, use_kub, service_name, app_id):
+    def find_environment_type(self, use_kub, service_name, app_id):
         """
         Check for vm or kubernetes
-        :return: True for vm and False for kubernetes
+        :return: Vm or Kubernetes
         """
 
         if use_kub == 'false':
-            return True
+            return 'Vm'
         else:
             isKubernetes = self.check_for_kubernetes_cluster(service_name, app_id)
 
             if isKubernetes:
-                return False
+                return 'Kubernetes'
             else:
-                return True
+                return 'Vm'
 
 

--- a/cartridges/plugins/wso2am-1.9.0/wso2am-startup-handler.py
+++ b/cartridges/plugins/wso2am-1.9.0/wso2am-startup-handler.py
@@ -235,6 +235,7 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
 
             member_ip = socket.gethostbyname(socket.gethostname())
             self.set_host_names_for_gw(app_id, member_ip)
+            self.export_env_var("CONFIG_PARAM_LOCAL_MEMBER_HOST", member_ip)
             set_system_properties = "-Dkm.ip=" + keymanager_ip + " -Dkm.port=" + km_port
             start_command = "exec ${CARBON_HOME}/bin/wso2server.sh -Dprofile=gateway-manager " + set_system_properties + " start"
 
@@ -272,6 +273,7 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
 
             member_ip = socket.gethostbyname(socket.gethostname())
             self.set_host_names_for_gw(app_id, member_ip)
+            self.export_env_var("CONFIG_PARAM_LOCAL_MEMBER_HOST", member_ip)
             set_system_properties = "-Dkm.ip=" + keymanager_ip + " -Dkm.port=" + km_port
 
             start_command = "exec ${CARBON_HOME}/bin/wso2server.sh -Dprofile=gateway-worker " + set_system_properties + " start"
@@ -332,6 +334,7 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
 
             member_ip = socket.gethostbyname(socket.gethostname())
             self.set_host_name(app_id, service_name, member_ip)
+            self.export_env_var("CONFIG_PARAM_LOCAL_MEMBER_HOST", member_ip)
             start_command = "exec ${CARBON_HOME}/bin/wso2server.sh -Dprofile=api-publisher start"
 
 
@@ -390,6 +393,7 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
 
             member_ip = socket.gethostbyname(socket.gethostname())
             self.set_host_name(app_id, service_name, member_ip)
+            self.export_env_var("CONFIG_PARAM_LOCAL_MEMBER_HOST", member_ip)
             start_command = "exec ${CARBON_HOME}/bin/wso2server.sh -Dprofile=api-store start"
 
 
@@ -436,6 +440,7 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
 
             member_ip = socket.gethostbyname(socket.gethostname())
             self.set_host_name(app_id, service_name, member_ip)
+            self.export_env_var("CONFIG_PARAM_LOCAL_MEMBER_HOST", member_ip)
             start_command = "exec ${CARBON_HOME}/bin/wso2server.sh start"
 
         else:

--- a/cartridges/plugins/wso2am-1.9.0/wso2am-startup-handler.py
+++ b/cartridges/plugins/wso2am-1.9.0/wso2am-startup-handler.py
@@ -51,6 +51,7 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
     CONST_WORKER = "worker"
     CONST_MANAGER = "manager"
     CONST_MGT = "mgt"
+    CONST_KEY_MANAGER_SERVICE_NAME = "wso2am-190-km"
     CONST_GATEWAY_MANAGER_SERVICE_NAME = "wso2am-190-gw-manager"
     CONST_GATEWAY_WORKER_SERVICE_NAME = "wso2am-190-gw-worker"
     CONST_PUBLISHER_SERVICE_NAME = "wso2am-190-pub"
@@ -90,6 +91,9 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
     ENV_CONFIG_PARAM_GATEWAY_WORKER_PT_HTTP_PROXY_PORT = 'CONFIG_PARAM_GATEWAY_WORKER_PT_HTTP_PROXY_PORT'
     ENV_CONFIG_PARAM_GATEWAY_WORKER_PT_HTTPS_PROXY_PORT = 'CONFIG_PARAM_GATEWAY_WORKER_PT_HTTPS_PROXY_PORT'
 
+    # This is payload parameter which enables to use an external lb when using kubernetes. Use false when using with kub.
+    ENV_CONFIG_PARAM_USE_KUBERNETES = 'CONFIG_PARAM_USE_KUBERNETES'
+
     def run_plugin(self, values):
 
         # read Port_mappings, Application_Id, MB_IP and Topology, clustering, membership_scheme from 'values'
@@ -102,6 +106,7 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
         membership_scheme = values.get(self.ENV_CONFIG_PARAM_MEMBERSHIP_SCHEME)
         clustering = values.get(self.ENV_CONFIG_PARAM_CLUSTERING, 'false')
         my_cluster_id = values[self.CONST_CLUSTER_ID]
+        use_kubernetes = values.get(self.ENV_CONFIG_PARAM_USE_KUBERNETES, 'true')
 
         # log above values
         WSO2AMStartupHandler.log.info("Port Mappings: %s" % port_mappings_str)
@@ -158,6 +163,7 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
             # remove previous data from metadata service
             # add new values to meta data service - key manager ip and mgt-console port
             # retrieve values from meta data service - gateway ip, gw mgt console port, pt http and https ports
+            # check deployment is vm, if vm update /etc/hosts with values
             # export retrieve values as environment variables
             # set the start command
 
@@ -174,9 +180,23 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
             gateway_worker_ports = self.get_data_from_meta_data_service(app_id,
                                                                         self.CONST_CONFIG_PARAM_GATEWAY_WORKER_PORTS)
 
-            self.export_env_var(self.ENV_CONFIG_PARAM_GATEWAY_IP, gateway_ip)
+            is_vm = self.check_vm_or_kubernetes(use_kubernetes, service_name, app_id)
+
+            if is_vm:
+                gateway_host_name = self.get_host_name_from_cluster(self.CONST_GATEWAY_MANAGER_SERVICE_NAME)
+                gateway_worker_host_name = self.get_host_name_from_cluster(self.CONST_GATEWAY_WORKER_SERVICE_NAME)
+                gateway_host = gateway_host_name
+                gateway_worker_host = gateway_worker_host_name
+
+                self.update_hosts_file(gateway_ip, gateway_host_name)
+                self.update_hosts_file(gateway_worker_ip, gateway_worker_host_name)
+            else:
+                gateway_host = gateway_ip
+                gateway_worker_host = gateway_worker_ip
+
+            self.export_env_var(self.ENV_CONFIG_PARAM_GATEWAY_IP, gateway_host)
             self.set_gateway_ports(gateway_ports)
-            self.export_env_var(self.ENV_CONFIG_PARAM_GATEWAY_WORKER_IP, gateway_worker_ip)
+            self.export_env_var(self.ENV_CONFIG_PARAM_GATEWAY_WORKER_IP, gateway_worker_host)
             self.set_gateway_worker_ports(gateway_worker_ports)
 
             start_command = "exec ${CARBON_HOME}/bin/wso2server.sh -Dprofile=api-key-manager start"
@@ -186,6 +206,7 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
             # remove previous data from metadata service
             # add new values to meta data service - gateway ip, mgt-console port, pt http and https ports
             # retrieve values from meta data service - keymanager ip and mgt console port
+            # check deployment is vm, if vm update /etc/hosts with values
             # export retrieve values as environment variables
             # export hostname for gateway-manager
             # set the start command
@@ -200,7 +221,16 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
             keymanager_ip = self.get_data_from_meta_data_service(app_id, self.ENV_CONFIG_PARAM_KEYMANAGER_IP)
             keymanager_ports = self.get_data_from_meta_data_service(app_id, self.CONST_CONFIG_PARAM_KEYMANAGER_PORTS)
 
-            self.export_env_var(self.ENV_CONFIG_PARAM_KEYMANAGER_IP, keymanager_ip)
+            is_vm = self.check_vm_or_kubernetes(use_kubernetes, service_name, app_id)
+
+            if is_vm:
+                keymanager_host_name = self.get_host_name_from_cluster(self.CONST_KEY_MANAGER_SERVICE_NAME)
+                keymanager_host = keymanager_host_name
+                self.update_hosts_file(keymanager_ip, keymanager_host_name)
+            else:
+                keymanager_host = keymanager_ip
+
+            self.export_env_var(self.ENV_CONFIG_PARAM_KEYMANAGER_IP, keymanager_host)
             km_port = self.set_keymanager_ports(keymanager_ports)
 
             member_ip = socket.gethostbyname(socket.gethostname())
@@ -208,31 +238,13 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
             set_system_properties = "-Dkm.ip=" + keymanager_ip + " -Dkm.port=" + km_port
             start_command = "exec ${CARBON_HOME}/bin/wso2server.sh -Dprofile=gateway-manager " + set_system_properties + " start"
 
-            ##################################
-            # for wka clustering - remove wka property in json
-
-            if membership_scheme == "wka":
-
-                self.export_env_var("CONFIG_PARAM_LOCAL_MEMBER_HOST", member_ip)
-                st_ips = self.read_member_ip_of_service(self.CONST_GATEWAY_WORKER_SERVICE_NAME, app_id)
-                st = st_ips.split(":")
-
-                ipset = ""
-                for i in st:
-                    if i is not "":
-                        ipset = ipset + i + ":4000,"
-
-                ipset = ipset[:-1]
-
-                wka_members = "[" + ipset + "]"
-                self.export_env_var("CONFIG_PARAM_WKA_MEMBERS", wka_members)
-                ####################################
 
         elif profile == self.CONST_GATEWAY_WORKER:
             # this is for gateway worker profile
             # remove previous data from metadata service
             # retrieve values from meta data service - keymanager ip and mgt console port
             # export retrieve values as environment variables
+            # check deployment is vm, if vm update /etc/hosts with values
             # export hostname for gateway-worker
             # set the start command
 
@@ -246,7 +258,16 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
             keymanager_ip = self.get_data_from_meta_data_service(app_id, self.ENV_CONFIG_PARAM_KEYMANAGER_IP)
             keymanager_ports = self.get_data_from_meta_data_service(app_id, self.CONST_CONFIG_PARAM_KEYMANAGER_PORTS)
 
-            self.export_env_var(self.ENV_CONFIG_PARAM_KEYMANAGER_IP, keymanager_ip)
+            is_vm = self.check_vm_or_kubernetes(use_kubernetes, service_name, app_id)
+
+            if is_vm:
+                keymanager_host_name = self.get_host_name_from_cluster(self.CONST_KEY_MANAGER_SERVICE_NAME)
+                keymanager_host = keymanager_host_name
+                self.update_hosts_file(keymanager_ip, keymanager_host_name)
+            else:
+                keymanager_host = keymanager_ip
+
+            self.export_env_var(self.ENV_CONFIG_PARAM_KEYMANAGER_IP, keymanager_host)
             km_port = self.set_keymanager_ports(keymanager_ports)
 
             member_ip = socket.gethostbyname(socket.gethostname())
@@ -255,31 +276,13 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
 
             start_command = "exec ${CARBON_HOME}/bin/wso2server.sh -Dprofile=gateway-worker " + set_system_properties + " start"
 
-            ##################################
-            # for wka clustering - remove wka property in json
-
-            if membership_scheme == "wka":
-
-                self.export_env_var("CONFIG_PARAM_LOCAL_MEMBER_HOST", member_ip)
-                st_ips = self.read_member_ip_of_service(self.CONST_GATEWAY_MANAGER_SERVICE_NAME, app_id)
-                st = st_ips.split(":")
-
-                ipset = ""
-                for i in st:
-                    if i is not "":
-                        ipset = ipset + i + ":4000,"
-
-                ipset = ipset[:-1]
-
-                wka_members = "[" + ipset + "]"
-                self.export_env_var("CONFIG_PARAM_WKA_MEMBERS", wka_members)
-                ####################################
 
         elif profile == self.CONST_PUBLISHER:
             # this is for publisher profile
             # remove previous data from metadata service
             # add new values to meta data service - publisher ip
             # retrieve values from meta data service - store ip, km ip and mgt console port, gw ip, mgt console port, pt http and https ports
+            # check deployment is vm, if vm update /etc/hosts with values
             # export retrieve values as environment variables
             # export hostname for publisher
             # set the start command
@@ -297,34 +300,47 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
             gateway_worker_ports = self.get_data_from_meta_data_service(app_id,
                                                                         self.CONST_CONFIG_PARAM_GATEWAY_WORKER_PORTS)
 
-            self.export_env_var(self.ENV_CONFIG_PARAM_STORE_IP, store_ip)
-            self.export_env_var(self.ENV_CONFIG_PARAM_KEYMANAGER_IP, keymanager_ip)
+            is_vm = self.check_vm_or_kubernetes(use_kubernetes, service_name, app_id)
+
+            if is_vm:
+                keymanager_host_name = self.get_host_name_from_cluster(self.CONST_KEY_MANAGER_SERVICE_NAME)
+                gateway_host_name = self.get_host_name_from_cluster(self.CONST_GATEWAY_MANAGER_SERVICE_NAME)
+                gateway_worker_host_name = self.get_host_name_from_cluster(self.CONST_GATEWAY_WORKER_SERVICE_NAME)
+                store_host_name = self.get_host_name_from_cluster(self.CONST_STORE_SERVICE_NAME)
+                keymanager_host = keymanager_host_name
+                gateway_host = gateway_host_name
+                gateway_worker_host = gateway_worker_host_name
+                store_host = store_host_name
+
+                self.update_hosts_file(keymanager_ip, keymanager_host_name)
+                self.update_hosts_file(gateway_ip, gateway_host_name)
+                self.update_hosts_file(gateway_worker_ip, gateway_worker_host_name)
+                self.update_hosts_file(store_ip, store_host_name)
+            else:
+                keymanager_host = keymanager_ip
+                gateway_host = gateway_ip
+                gateway_worker_host = gateway_worker_ip
+                store_host = store_ip
+
+            self.export_env_var(self.ENV_CONFIG_PARAM_STORE_IP, store_host)
+            self.export_env_var(self.ENV_CONFIG_PARAM_KEYMANAGER_IP, keymanager_host)
             self.set_keymanager_ports(keymanager_ports)
-            self.export_env_var(self.ENV_CONFIG_PARAM_GATEWAY_IP, gateway_ip)
+            self.export_env_var(self.ENV_CONFIG_PARAM_GATEWAY_IP, gateway_host)
             self.set_gateway_ports(gateway_ports)
-            self.export_env_var(self.ENV_CONFIG_PARAM_GATEWAY_WORKER_IP, gateway_worker_ip)
+            self.export_env_var(self.ENV_CONFIG_PARAM_GATEWAY_WORKER_IP, gateway_worker_host)
             self.set_gateway_worker_ports(gateway_worker_ports)
 
             member_ip = socket.gethostbyname(socket.gethostname())
             self.set_host_name(app_id, service_name, member_ip)
             start_command = "exec ${CARBON_HOME}/bin/wso2server.sh -Dprofile=api-publisher start"
 
-            ##################################
-            # for wka clustering - remove wka property in json
-
-            if membership_scheme == "wka":
-                self.export_env_var("CONFIG_PARAM_LOCAL_MEMBER_HOST", member_ip)
-                st_ips = self.read_member_ip_of_service(self.CONST_STORE_SERVICE_NAME, app_id)
-                st = st_ips.split(":")
-                wka_members = "[" + st[0] + ":4000]"
-                self.export_env_var("CONFIG_PARAM_WKA_MEMBERS", wka_members)
-                ####################################
 
         elif profile == self.CONST_STORE:
             # this is for store profile
             # remove previous data from metadata service
             # add new values to meta data service - store ip
             # retrieve values from meta data service - publisher ip, km ip and mgt console port, gw ip, mgt console port, pt http and https ports
+            # check deployment is vm, if vm update /etc/hosts with values
             # export retrieve values as environment variables
             # export hostname for store
             # set the start command
@@ -342,30 +358,45 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
             gateway_worker_ports = self.get_data_from_meta_data_service(app_id,
                                                                         self.CONST_CONFIG_PARAM_GATEWAY_WORKER_PORTS)
 
-            self.export_env_var(self.ENV_CONFIG_PARAM_STORE_IP, publisher_ip)
-            self.export_env_var(self.ENV_CONFIG_PARAM_KEYMANAGER_IP, keymanager_ip)
+            is_vm = self.check_vm_or_kubernetes(use_kubernetes, service_name, app_id)
+
+            if is_vm:
+                keymanager_host_name = self.get_host_name_from_cluster(self.CONST_KEY_MANAGER_SERVICE_NAME)
+                gateway_host_name = self.get_host_name_from_cluster(self.CONST_GATEWAY_MANAGER_SERVICE_NAME)
+                gateway_worker_host_name = self.get_host_name_from_cluster(self.CONST_GATEWAY_WORKER_SERVICE_NAME)
+                publisher_host_name = self.get_host_name_from_cluster(self.CONST_PUBLISHER_SERVICE_NAME)
+                keymanager_host = keymanager_host_name
+                gateway_host = gateway_host_name
+                gateway_worker_host = gateway_worker_host_name
+                publisher_host = publisher_host_name
+
+                self.update_hosts_file(keymanager_ip, keymanager_host_name)
+                self.update_hosts_file(gateway_ip, gateway_host_name)
+                self.update_hosts_file(gateway_worker_ip, gateway_worker_host_name)
+                self.update_hosts_file(publisher_ip, publisher_host_name)
+            else:
+                keymanager_host = keymanager_ip
+                gateway_host = gateway_ip
+                gateway_worker_host = gateway_worker_ip
+                publisher_host = publisher_ip
+
+            self.export_env_var(self.ENV_CONFIG_PARAM_STORE_IP, publisher_host)
+            self.export_env_var(self.ENV_CONFIG_PARAM_KEYMANAGER_IP, keymanager_host)
             self.set_keymanager_ports(keymanager_ports)
-            self.export_env_var(self.ENV_CONFIG_PARAM_GATEWAY_IP, gateway_ip)
+            self.export_env_var(self.ENV_CONFIG_PARAM_GATEWAY_IP, gateway_host)
             self.set_gateway_ports(gateway_ports)
-            self.export_env_var(self.ENV_CONFIG_PARAM_GATEWAY_WORKER_IP, gateway_worker_ip)
+            self.export_env_var(self.ENV_CONFIG_PARAM_GATEWAY_WORKER_IP, gateway_worker_host)
             self.set_gateway_worker_ports(gateway_worker_ports)
 
             member_ip = socket.gethostbyname(socket.gethostname())
             self.set_host_name(app_id, service_name, member_ip)
             start_command = "exec ${CARBON_HOME}/bin/wso2server.sh -Dprofile=api-store start"
 
-            ##########################################
-            if membership_scheme == "wka":
-                self.export_env_var("CONFIG_PARAM_LOCAL_MEMBER_HOST", member_ip)
-                st_ips = self.read_member_ip_of_service(self.CONST_PUBLISHER_SERVICE_NAME, app_id)
-                st = st_ips.split(":")
-                wka_members = "[" + st[0] + ":4000]"
-                self.export_env_var("CONFIG_PARAM_WKA_MEMBERS", wka_members)
-                ##########################################
 
         elif profile == self.CONST_PUBSTORE:
             # Publisher and Store runs on a same node (PubStore profile)
             # retrieve values from meta data service - store ip, km ip and mgt console port, gw ip, mgt console port, pt http and https ports
+            # check deployment is vm, if vm update /etc/hosts with values
             # export retrieve values as environment variables
             # export hostname for pubStore
             # set the start command
@@ -378,11 +409,29 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
             gateway_worker_ports = self.get_data_from_meta_data_service(app_id,
                                                                         self.CONST_CONFIG_PARAM_GATEWAY_WORKER_PORTS)
 
-            self.export_env_var(self.ENV_CONFIG_PARAM_KEYMANAGER_IP, keymanager_ip)
+            is_vm = self.check_vm_or_kubernetes(use_kubernetes, service_name, app_id)
+
+            if is_vm:
+                keymanager_host_name = self.get_host_name_from_cluster(self.CONST_KEY_MANAGER_SERVICE_NAME)
+                gateway_host_name = self.get_host_name_from_cluster(self.CONST_GATEWAY_MANAGER_SERVICE_NAME)
+                gateway_worker_host_name = self.get_host_name_from_cluster(self.CONST_GATEWAY_WORKER_SERVICE_NAME)
+                keymanager_host = keymanager_host_name
+                gateway_host = gateway_host_name
+                gateway_worker_host = gateway_worker_host_name
+
+                self.update_hosts_file(keymanager_ip, keymanager_host_name)
+                self.update_hosts_file(gateway_ip, gateway_host_name)
+                self.update_hosts_file(gateway_worker_ip, gateway_worker_host_name)
+            else:
+                keymanager_host = keymanager_ip
+                gateway_host = gateway_ip
+                gateway_worker_host = gateway_worker_ip
+
+            self.export_env_var(self.ENV_CONFIG_PARAM_KEYMANAGER_IP, keymanager_host)
             self.set_keymanager_ports(keymanager_ports)
-            self.export_env_var(self.ENV_CONFIG_PARAM_GATEWAY_IP, gateway_ip)
+            self.export_env_var(self.ENV_CONFIG_PARAM_GATEWAY_IP, gateway_host)
             self.set_gateway_ports(gateway_ports)
-            self.export_env_var(self.ENV_CONFIG_PARAM_GATEWAY_WORKER_IP, gateway_worker_ip)
+            self.export_env_var(self.ENV_CONFIG_PARAM_GATEWAY_WORKER_IP, gateway_worker_host)
             self.set_gateway_worker_ports(gateway_worker_ports)
 
             member_ip = socket.gethostbyname(socket.gethostname())
@@ -528,7 +577,7 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
         while mds_response is None:
             WSO2AMStartupHandler.log.info(
                 "Waiting for " + receive_data + " to be available from metadata service for app ID: %s" % app_id)
-            time.sleep(3)
+            time.sleep(1)
             mds_response = mdsclient.get(app=True)
             if mds_response is not None and mds_response.properties.get(receive_data) is None:
                 mds_response = None
@@ -604,22 +653,13 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
         Get the cluster_id of a service read from topology
         :return: cluster_id
         """
-
         cluster_id = None
-        clusters = None
-        topology = TopologyContext.topology
+        clusters = self.get_clusters_from_topology(service_name)
 
-        if topology is not None:
-            if topology.service_exists(service_name):
-                service = topology.get_service(service_name)
-                clusters = service.get_clusters()
-            else:
-                WSO2AMStartupHandler.log.warn("[Service] %s is not available in topology" % service_name)
-
-            if clusters is not None:
-                for cluster in clusters:
-                    if cluster.app_id == app_id:
-                        cluster_id = cluster.cluster_id
+        if clusters is not None:
+            for cluster in clusters:
+                if cluster.app_id == app_id:
+                    cluster_id = cluster.cluster_id
 
         return cluster_id
 
@@ -670,14 +710,7 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
         Get hostname for a service
         :return: hostname
         """
-        clusters = None
-        topology = TopologyContext().get_topology()
-
-        if topology.service_exists(service_name):
-            service = topology.get_service(service_name)
-            clusters = service.get_clusters()
-        else:
-            WSO2AMStartupHandler.log.error("[Service] %s is not available in topology" % service_name)
+        clusters = self.get_clusters_from_topology(service_name)
 
         if clusters is not None:
             for cluster in clusters:
@@ -686,36 +719,54 @@ class WSO2AMStartupHandler(ICartridgeAgentPlugin):
 
         return hostname
 
-    def read_member_ip_of_service(self, service_name, app_id):
+    def check_for_kubernetes_cluster(self, service_name, app_id):
         """
-        Get member ips from the topology for a service
-        :return: ip set
+        Check the deployment is kubernetes
+        :return: True
         """
-        clusters = None
-        topology = TopologyContext().get_topology()
-        members = None
-        member_ips = None
-
-        if topology.service_exists(service_name):
-            service = topology.get_service(service_name)
-            clusters = service.get_clusters()
-        else:
-            WSO2AMStartupHandler.log.error("[Service] %s is not available in topology" % service_name)
+        isKubernetes = False
+        clusters = self.get_clusters_from_topology(service_name)
 
         if clusters is not None:
             for cluster in clusters:
                 if cluster.app_id == app_id:
-                    members = cluster.get_members()
+                    isKubernetes = cluster.is_kubernetes_cluster
 
-        if members is not None:
-            member_ips = ""
-            for member in members:
-                ip = member.member_default_private_ip
-                if ip is not None or ip != "":
-                    member_ips = member_ips + ip +":"
+        return isKubernetes
 
-            WSO2AMStartupHandler.log.info("[Member_IPS] %s from topology" % member_ips)
 
-        return member_ips
+    def get_clusters_from_topology(self, service_name):
+        """
+        get clusters from topology
+        :return: clusters
+        """
+        clusters = None
+        topology = TopologyContext().get_topology()
+
+        if topology is not None:
+            if topology.service_exists(service_name):
+                service = topology.get_service(service_name)
+                clusters = service.get_clusters()
+            else:
+                WSO2AMStartupHandler.log.error("[Service] %s is not available in topology" % service_name)
+
+        return clusters
+
+
+    def check_vm_or_kubernetes(self, use_kub, service_name, app_id):
+        """
+        Check for vm or kubernetes
+        :return: True for vm and False for kubernetes
+        """
+
+        if use_kub == 'false':
+            return True
+        else:
+            isKubernetes = self.check_for_kubernetes_cluster(service_name, app_id)
+
+            if isKubernetes:
+                return False
+            else:
+                return True
 
 


### PR DESCRIPTION
This PR includes changes to support key manager ip to set as system properties. This is useful when giving a artifact repo. Also plugin has changed to support vm scenario. If vm, it will set the host name in template module and update the /etc/host with ip accordingly. If kubernetes, ips are set in the template. 

New payload parameter CONFIG_PARAM_USE_KUBERNETES can be set to false in the cartridge if an external load balancer is used in the kubernetes environment.