### PR TITLE
Fixing typo error in WSO2 AS cartridge common deploy.sh file

### DIFF
--- a/samples/applications/wso2as-521/scripts/common/deploy.sh
+++ b/samples/applications/wso2as-521/scripts/common/deploy.sh
@@ -31,7 +31,7 @@ iaas_cartridges_path=`cd "${script_path}/../../../../cartridges/${iaas}/${produc
 cartridges_groups_path=`cd "${script_path}/../../../../cartridge-groups/${product}"; pwd`
 autoscaling_policies_path=`cd "${script_path}/../../../../autoscaling-policies"; pwd`
 network_partitions_path=`cd "${script_path}/../../../../network-partitions/${iaas}"; pwd`
-deployment_policies_path=`cd "${script_path}/../../../../deployment-policies/${iass}"; pwd`
+deployment_policies_path=`cd "${script_path}/../../../../deployment-policies/${iaas}"; pwd`
 application_policies_path=`cd "${script_path}/../../../../application-policies/${iaas}"; pwd`
 
 network_partition_id="network-partition-${iaas}"


### PR DESCRIPTION
This p/r is to correct typo error in WSO2 AS cartridge common deploy.sh file.