### PR TITLE
Fixed alignment issue when adding an autoscaling policy

### DIFF
--- a/components/org.wso2.ppaas.manager.console/console/themes/privatePaaS/css/custom.css
+++ b/components/org.wso2.ppaas.manager.console/console/themes/privatePaaS/css/custom.css
@@ -355,3 +355,7 @@ h3.panel-title {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
 }
+
+.col-md-4.container-memoryConsumption {
+    width: 33%;
+}


### PR DESCRIPTION
This fix overrides the width value of memory consumption container. This can be only seen in PPaas UI and not in Apache Stratos. This is due to the custom UI changes in ppaas.